### PR TITLE
Re-add support to set custom vanilla chests drops

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ tasks.withType(ScalaCompile) {
 }
 
 minecraft {
-    version = "1.11.2-13.20.0.2255"
+    version = "1.11.2-13.20.0.2282"
     runDir = "run"
     mappings = "snapshot_20170317"
 

--- a/src/main/scala/com/easyforger/base/EasyForger.scala
+++ b/src/main/scala/com/easyforger/base/EasyForger.scala
@@ -4,6 +4,7 @@
  */
 package com.easyforger.base
 
+import com.easyforger.chests.VanillaChests
 import com.easyforger.creatures.VanillaCreatures
 import com.easyforger.dungeons.VanillaDungeons
 import com.easyforger.recipes.RecipeSupport
@@ -13,6 +14,7 @@ trait EasyForger
   extends VanillaItems
   with VanillaDungeons
   with VanillaCreatures
+  with VanillaChests
   with RecipeSupport {
 
   def modId: String

--- a/src/main/scala/com/easyforger/base/LootTableLoadEventReplacer.scala
+++ b/src/main/scala/com/easyforger/base/LootTableLoadEventReplacer.scala
@@ -1,0 +1,23 @@
+/*
+ * This file is part of EasyForger which is released under GPLv3 License.
+ * See file LICENSE.txt or go to http://www.gnu.org/licenses/gpl-3.0.en.html for full license details.
+ */
+package com.easyforger.base
+
+import net.minecraft.util.ResourceLocation
+import net.minecraftforge.event.LootTableLoadEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import org.apache.logging.log4j.LogManager
+
+final class LootTableLoadEventReplacer(replacements: Map[ResourceLocation, String]) {
+  private val logger = LogManager.getLogger
+
+  @SubscribeEvent
+  def onLootTableLoadEvent(event: LootTableLoadEvent): Unit =
+    replacements.get(event.getName).foreach { newLootTable =>
+      logger.info(s"Replacing ${event.getName}")
+
+      val lootTable = event.getLootTableManager.getLootTableFromLocation(new ResourceLocation(newLootTable))
+      event.setTable(lootTable)
+    }
+}

--- a/src/main/scala/com/easyforger/chests/Chests.scala
+++ b/src/main/scala/com/easyforger/chests/Chests.scala
@@ -1,0 +1,29 @@
+/*
+ * This file is part of EasyForger which is released under GPLv3 License.
+ * See file LICENSE.txt or go to http://www.gnu.org/licenses/gpl-3.0.en.html for full license details.
+ */
+package com.easyforger.chests
+
+import net.minecraft.util.ResourceLocation
+import net.minecraft.world.storage.loot.LootTableList
+
+final case class Chest(resourceLocation: ResourceLocation)
+
+sealed trait Chests {
+  val spawnBonus            = Chest(LootTableList.CHESTS_SPAWN_BONUS_CHEST)
+  val endCityTreasure       = Chest(LootTableList.CHESTS_END_CITY_TREASURE)
+  val simpleDungeon         = Chest(LootTableList.CHESTS_SIMPLE_DUNGEON)
+  val villageBlacksmith     = Chest(LootTableList.CHESTS_VILLAGE_BLACKSMITH)
+  val abandonedMineshaft    = Chest(LootTableList.CHESTS_ABANDONED_MINESHAFT)
+  val netherBridge          = Chest(LootTableList.CHESTS_NETHER_BRIDGE)
+  val strongholdLibrary     = Chest(LootTableList.CHESTS_STRONGHOLD_LIBRARY)
+  val strongholdCrossing    = Chest(LootTableList.CHESTS_STRONGHOLD_CROSSING)
+  val strongholdCorridor    = Chest(LootTableList.CHESTS_STRONGHOLD_CORRIDOR)
+  val desertPyramid         = Chest(LootTableList.CHESTS_DESERT_PYRAMID)
+  val jungleTemple          = Chest(LootTableList.CHESTS_JUNGLE_TEMPLE)
+  val jungleTempleDispenser = Chest(LootTableList.CHESTS_JUNGLE_TEMPLE_DISPENSER)
+  val igloo                 = Chest(LootTableList.CHESTS_IGLOO_CHEST)
+  val woodlandMansion       = Chest(LootTableList.CHESTS_WOODLAND_MANSION)
+}
+
+object Chests extends Chests

--- a/src/main/scala/com/easyforger/chests/VanillaChests.scala
+++ b/src/main/scala/com/easyforger/chests/VanillaChests.scala
@@ -1,0 +1,21 @@
+/*
+ * This file is part of EasyForger which is released under GPLv3 License.
+ * See file LICENSE.txt or go to http://www.gnu.org/licenses/gpl-3.0.en.html for full license details.
+ */
+package com.easyforger.chests
+
+import com.easyforger.base.LootTableLoadEventReplacer
+import net.minecraftforge.common.MinecraftForge
+
+trait VanillaChests {
+  // cheap trick to avoid this having to be imported in the user code
+  val Chests = com.easyforger.chests.Chests
+
+  def chestDrops(chestsMap: (Chest, String)*): Unit = {
+    val replacer = new LootTableLoadEventReplacer(
+      chestsMap.map { case (k, v) => (k.resourceLocation, v) }.toMap
+    )
+
+    MinecraftForge.EVENT_BUS.register(replacer)
+  }
+}

--- a/src/main/scala/com/easyforger/dungeons/VanillaDungeons.scala
+++ b/src/main/scala/com/easyforger/dungeons/VanillaDungeons.scala
@@ -9,21 +9,20 @@ import net.minecraft.util.ResourceLocation
 import net.minecraftforge.common.DungeonHooks
 
 /**
- * According to Forge, the default dungeon possibilities are:
- * Spider   100
- * Skeleton 100
- * Zombie   200
- */
+  * See forge's DungeonHooks for the default probability levels.
+  */
 trait VanillaDungeons {
   self: VanillaCreatures =>
 
-  def dungeonMobs(mobMap: (EntityName.EntityName, Int)*): Unit = mapMobSpawn(mobMap: _*)
+  def dungeonMobs(mobMap: (EntityName.EntityName, Int)*): Unit =
+    mapMobSpawn(mobMap: _*)
 
-  private def mapMobSpawn(mobMap: (EntityName.EntityName, Int)*) = mobMap.foreach {
-    case (entityName, spawnChance) =>
-      val resource = new ResourceLocation(entityName.toString)
+  private def mapMobSpawn(mobMap: (EntityName.EntityName, Int)*) =
+    mobMap.foreach {
+      case (entityName, spawnChance) =>
+        val resource = new ResourceLocation(entityName.toString)
 
-      DungeonHooks.removeDungeonMob(resource)
-      DungeonHooks.addDungeonMob(resource, spawnChance)
-  }
+        DungeonHooks.removeDungeonMob(resource)
+        DungeonHooks.addDungeonMob(resource, spawnChance)
+    }
 }

--- a/src/main/scala/com/easyforger/recipes/RecipeSupport.scala
+++ b/src/main/scala/com/easyforger/recipes/RecipeSupport.scala
@@ -10,8 +10,6 @@ import net.minecraft.init.{Blocks, Items}
 import net.minecraft.item.{EnumDyeColor, Item, ItemStack}
 import net.minecraftforge.fml.common.registry.GameRegistry
 
-import scala.util.Try
-
 trait RecipeSupport {
   implicit def toRecipeItemStack(item: Item): RecipeItemStack = RecipeItemStack(new ItemStack(item, 1), RecipeSupport.shortForItem(item))
   implicit def toRecipeItemStack(block: Block): RecipeItemStack = RecipeItemStack(new ItemStack(block, 1), RecipeSupport.shortForBlock(block))
@@ -69,7 +67,8 @@ object RecipeSupport {
     Blocks.SPRUCE_DOOR -> 's'
   )
 
-  def shortForItem(item: Item): Char = new ItemStack(item).getDisplayName.toLowerCase.charAt(0)
+  def shortForItem(item: Item): Char =
+    new ItemStack(item).getDisplayName.toLowerCase.charAt(0)
 
   def shortForSpecialItem(item: Item, meta: Int): Char =
     if (item == Items.DYE)
@@ -78,7 +77,10 @@ object RecipeSupport {
       errorShort
 
   def shortForBlock(block: Block): Char =
-    Try(shortForItem(Item.getItemFromBlock(block))).toOption.getOrElse(blockShorts.getOrElse(block, errorShort))
+    Item.getItemFromBlock(block) match {
+      case Items.AIR  => blockShorts.getOrElse(block, errorShort)
+      case item: Any  => shortForItem(item)
+    }
 
   def calcMCParamsArray(craftRecipe: CraftingRecipe): Array[Object] = {
     val params = craftRecipe.shape.get.trim.replace('.', ' ').split("\n")
@@ -89,5 +91,4 @@ object RecipeSupport {
 
     params ++ acronyms
   }
-
 }


### PR DESCRIPTION
This support now is based on the LootTableLoadEvent and requires the
creation of a loot table json file.

closes #72