### PR TITLE
Read project version from a central location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,8 +72,17 @@ allprojects {
             exclude 'mcmod.info'
         }
     }
+
+    task updateVersionFile {
+        def versionFile = file("${project.rootProject.sourceSets.main.scala.srcDirs[0]}/com/easyforger/util/Version.scala")
+        def contents = file("${project.rootDir}/project/Version.scala").text
+
+        versionFile.write(contents.replace("{version}", project.version.toString()))
+    }
+    build.dependsOn updateVersionFile
 }
 
+// release stuff
 apply plugin: 'com.novoda.bintray-release'
 
 group = "com.easyforger"

--- a/mods/src/main/scala/com/easyforger/samples/blocks/BlocksMod.scala
+++ b/mods/src/main/scala/com/easyforger/samples/blocks/BlocksMod.scala
@@ -5,12 +5,13 @@
 package com.easyforger.samples.blocks
 
 import com.easyforger.base.EasyForger
+import com.easyforger.util.Version
 import net.minecraft.init.Items
 import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.Mod.EventHandler
 import net.minecraftforge.fml.common.event.FMLInitializationEvent
 
-@Mod(modid = BlocksMod.modId, name = "EasyForger Blocks Sample Mod", version = "0.5", modLanguage = "scala")
+@Mod(modid = BlocksMod.modId, name = "EasyForger Blocks Sample Mod", version = Version.version, modLanguage = "scala")
 object BlocksMod extends EasyForger {
   final val modId = "easyforger_blocks"
 

--- a/mods/src/main/scala/com/easyforger/samples/chests/LockedChestsMod.scala
+++ b/mods/src/main/scala/com/easyforger/samples/chests/LockedChestsMod.scala
@@ -4,12 +4,13 @@
  */
 package com.easyforger.samples.chests
 
+import com.easyforger.util.Version
 import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.Mod.EventHandler
 import net.minecraftforge.fml.common.event.FMLInitializationEvent
 import net.minecraftforge.fml.common.registry.GameRegistry
 
-@Mod(modid = LockedChestsMod.modId, name = "EasyForger Locked Chests Mod", version = "0.5", modLanguage = "scala")
+@Mod(modid = LockedChestsMod.modId, name = "EasyForger Locked Chests Mod", version = Version.version, modLanguage = "scala")
 object LockedChestsMod {
   final val modId = "easyforger_lockedchests"
 

--- a/mods/src/main/scala/com/easyforger/samples/items/ItemsMod.scala
+++ b/mods/src/main/scala/com/easyforger/samples/items/ItemsMod.scala
@@ -5,13 +5,14 @@
 package com.easyforger.samples.items
 
 import com.easyforger.base.EasyForger
+import com.easyforger.util.Version
 import net.minecraft.init.{Blocks, Items}
 import net.minecraft.item.ItemStack
 import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.Mod.EventHandler
 import net.minecraftforge.fml.common.event.FMLInitializationEvent
 
-@Mod(modid = ItemsMod.modId, name = "EasyForger Items Sample Mod", version = "0.5", modLanguage = "scala")
+@Mod(modid = ItemsMod.modId, name = "EasyForger Items Sample Mod", version = Version.version, modLanguage = "scala")
 object ItemsMod extends EasyForger {
   final val modId = "easyforger_items"
 

--- a/mods/src/main/scala/com/easyforger/samples/lavasuit/LavaSuitMod.scala
+++ b/mods/src/main/scala/com/easyforger/samples/lavasuit/LavaSuitMod.scala
@@ -5,6 +5,7 @@
 package com.easyforger.samples.lavasuit
 
 import com.easyforger.base.EasyForger
+import com.easyforger.util.Version
 import net.minecraft.init.{Items, SoundEvents}
 import net.minecraft.inventory.EntityEquipmentSlot
 import net.minecraftforge.common.util.EnumHelper
@@ -12,7 +13,7 @@ import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.Mod.EventHandler
 import net.minecraftforge.fml.common.event.FMLInitializationEvent
 
-@Mod(modid = LavaSuitMod.modId, name = "EasyForger Armor LavaSuit Mod", version = "0.5", modLanguage = "scala")
+@Mod(modid = LavaSuitMod.modId, name = "EasyForger Armor LavaSuit Mod", version = Version.version, modLanguage = "scala")
 object LavaSuitMod extends EasyForger {
   final val modId = "easyforger_lavasuit"
   val materialName = "lavasuit"

--- a/mods/src/main/scala/com/easyforger/samples/misc/CreaturesMod.scala
+++ b/mods/src/main/scala/com/easyforger/samples/misc/CreaturesMod.scala
@@ -5,12 +5,13 @@
 package com.easyforger.samples.misc
 
 import com.easyforger.base.EasyForger
+import com.easyforger.util.Version
 import net.minecraft.init.Items
 import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.Mod.EventHandler
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent
 
-@Mod(modid = CreaturesMod.modId, name = "EasyForger Vanilla Creatures Replacements", version = "0.5.1", modLanguage = "scala")
+@Mod(modid = CreaturesMod.modId, name = "EasyForger Vanilla Creatures Replacements", version = Version.version, modLanguage = "scala")
 object CreaturesMod extends EasyForger {
   final val modId = "easyforger_creatures"
 

--- a/mods/src/main/scala/com/easyforger/samples/misc/DungeonsMod.scala
+++ b/mods/src/main/scala/com/easyforger/samples/misc/DungeonsMod.scala
@@ -5,11 +5,12 @@
 package com.easyforger.samples.misc
 
 import com.easyforger.base.EasyForger
+import com.easyforger.util.Version
 import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.Mod.EventHandler
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent
 
-@Mod(modid = DungeonsMod.modId, name = "EasyForger Dungeons Mod", version = "0.6", modLanguage = "scala")
+@Mod(modid = DungeonsMod.modId, name = "EasyForger Dungeons Mod", version = Version.version, modLanguage = "scala")
 object DungeonsMod extends EasyForger {
   final val modId = "easyforger_dungeons"
 

--- a/mods/src/main/scala/com/easyforger/samples/misc/RecipesMod.scala
+++ b/mods/src/main/scala/com/easyforger/samples/misc/RecipesMod.scala
@@ -5,12 +5,13 @@
 package com.easyforger.samples.misc
 
 import com.easyforger.base.EasyForger
+import com.easyforger.util.Version
 import net.minecraft.init.{Blocks, Enchantments, Items}
 import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.Mod.EventHandler
 import net.minecraftforge.fml.common.event.FMLInitializationEvent
 
-@Mod(modid = RecipesMod.modId, name = "EasyForger Recipes Examples", version = "0.5", modLanguage = "scala")
+@Mod(modid = RecipesMod.modId, name = "EasyForger Recipes Examples", version = Version.version, modLanguage = "scala")
 object RecipesMod extends EasyForger {
   final val modId = "easyforger_recipes"
 

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,0 +1,9 @@
+/*
+ * This file is part of EasyForger which is released under GPLv3 License.
+ * See file LICENSE.txt or go to http://www.gnu.org/licenses/gpl-3.0.en.html for full license details.
+ */
+package com.easyforger.util
+
+object Version {
+  final val version = "{version}"
+}

--- a/src/main/scala/com/easyforger/util/Version.scala
+++ b/src/main/scala/com/easyforger/util/Version.scala
@@ -1,0 +1,9 @@
+/*
+ * This file is part of EasyForger which is released under GPLv3 License.
+ * See file LICENSE.txt or go to http://www.gnu.org/licenses/gpl-3.0.en.html for full license details.
+ */
+package com.easyforger.util
+
+object Version {
+  final val version = "0.6-1.11.2"
+}

--- a/tester/src/main/scala/com/easyforger/tester/uTestRunnerMod.scala
+++ b/tester/src/main/scala/com/easyforger/tester/uTestRunnerMod.scala
@@ -8,6 +8,7 @@ import com.easyforger.base.{EasyForger, LootTableLoadEventReplacerTest}
 import com.easyforger.creatures.CreaturesHandlerTest
 import com.easyforger.items.EFItemArmorTest
 import com.easyforger.recipes.test.{RecipeSupportTest, RegisterRecipesTest, ShapedRecipesTest, SmeltingRecipesTest}
+import com.easyforger.util.Version
 import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.Mod.EventHandler
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent
@@ -15,7 +16,7 @@ import utest.TestRunner
 
 import scala.util.control.NonFatal
 
-@Mod(modid = uTestRunnerMod.modId, name = "EasyForger Integration Tester", version = "0.6", modLanguage = "scala")
+@Mod(modid = uTestRunnerMod.modId, name = "EasyForger Integration Tester", version = Version.version, modLanguage = "scala")
 object uTestRunnerMod extends EasyForger {
   final val modId = "easyforger-integration-tester"
 


### PR DESCRIPTION
A Version.scala file is generated, with the current project version, so
that the sample mods and the integration test runner can read this information
from a single place.

closes #100