### PR TITLE
Add i18n for the monsters in the creatures sample mod

### DIFF
--- a/mods/src/main/resources/assets/easyforger_blocks/lang/en_US.lang
+++ b/mods/src/main/resources/assets/easyforger_blocks/lang/en_US.lang
@@ -1,1 +1,2 @@
+
 tile.easyforger_blocks_clothblock.name=Cloth Block

--- a/mods/src/main/resources/assets/easyforger_blocks/lang/pt_BR.lang
+++ b/mods/src/main/resources/assets/easyforger_blocks/lang/pt_BR.lang
@@ -1,1 +1,2 @@
+
 tile.easyforger_blocks_clothblock.name=Bloco de Pano

--- a/mods/src/main/resources/assets/easyforger_creatures/lang/en_US.lang
+++ b/mods/src/main/resources/assets/easyforger_creatures/lang/en_US.lang
@@ -1,0 +1,4 @@
+
+entity.EasyForgerCreeper.name=EFCreeper
+entity.EasyForgerZombie.name=EFZombie
+entity.EasyForgerSkeleton.name=EFSkeleton


### PR DESCRIPTION
This has to be done in the mod side, instead of directly by EasyForger.
Technically, this is the case because we need the modId to locate the
i18n file, which only exists for the user created mod.

The con for this solution is the the user has to add the i18n file, if she
wants to avoid the un-i18n string.

The pro is that it is very easy to the user to customize the monster name.

closes #74